### PR TITLE
manage.sh now accepts a --skip-install command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@ set -e # everything must succeed.
 if [ ! -d venv ]; then
     virtualenv --python=`which python2` venv
 fi
+
 source venv/bin/activate
 
 if [ ! -e src/core/settings.py ]; then
@@ -11,5 +12,7 @@ if [ ! -e src/core/settings.py ]; then
     ln -s dev_settings.py settings.py
     cd ../../
 fi
+
 pip install -r requirements.txt
-python src/manage.py migrate
+
+python src/manage.py migrate --no-input

--- a/manage.sh
+++ b/manage.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
 # @description convenience wrapper around Django's runserver command
-source install.sh > /dev/null
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+
+skip_install=$1
+if test "$skip_install" = "--skip-install"; then
+    shift # like 'pop' but for positional args
+else
+    source install.sh > /dev/null
+fi
+
+source venv/bin/activate
 ./src/manage.py $@


### PR DESCRIPTION
this is important if it's called every minute by a cron job

install.sh migrate command no longer prompts for input