### PR TITLE
Switch to psycopg-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Django==1.11.20
 #djangorestframework==3.8.2
 django-rest-swagger==0.3.10
 djangorestframework==3.7.7
-psycopg2==2.7.5
+psycopg2-binary==2.7.5
 pylint==2.1.1
 pylint-django==2.0.2
 requests==2.20.0


### PR DESCRIPTION
Run into https://github.com/elifesciences/elife-dashboard-formula/pull/13#issuecomment-473357024 and I want this to stop compiling from sources and breaking everytime a new PostgreSQL version is released.